### PR TITLE
Use extrinsic sizing for background image

### DIFF
--- a/postcss.config.cjs
+++ b/postcss.config.cjs
@@ -1,4 +1,3 @@
-const autoprefixer = require("autoprefixer");
 module.exports = {
-  plugins: [require("autoprefixer"), require("cssnano"), autoprefixer],
+  plugins: [require("autoprefixer"), require("cssnano")],
 };

--- a/src/components/lazy-background-image.svelte
+++ b/src/components/lazy-background-image.svelte
@@ -28,10 +28,16 @@
 <style>
   img {
     position: fixed;
-    bottom: 0;
+    top: 0;
     left: 0;
     width: 100%;
-    height: 100%;
+
+    /* from https://taylor.callsen.me/working-with-hero-image-height-in-mobile-browsers/ */
+    height: 100vh;
+    height: -moz-available;
+    height: -webkit-fill-available;
+    height: fill-available;
+
     z-index: -1;
     user-select: none;
     object-fit: cover;


### PR DESCRIPTION
Should fix the issue where the background image jumps when scrolling on mobile viewports because the address bar disappears.